### PR TITLE
Standardize building metadata and fix meter assignments

### DIFF
--- a/metadata/building1.yaml
+++ b/metadata/building1.yaml
@@ -4,37 +4,38 @@ elec_meters:
   1: &sided_whole_building
     site_meter: true
     device_model: SIDED_whole_building
-  2: *sided_whole_building
-  3: &emonitor
-    submeter_of: 0 
+  2: &emonitor      # Meter for EVSE
+    submeter_of: 1
     device_model: eMonitor
+  3: *emonitor      # Meter for PV
+  4: *emonitor      # Meter for CS  
+  5: *emonitor      # Meter for CHP
+  6: *emonitor      # Meter for BA
 
 appliances:
 - original_name: EVSE
-  type: Plug-in electric vehicle station
+  type: plug-in electric vehicle station
   instance: 1
-  meters: [3]   
+  meters: [2]   
 
 - original_name: PV
-  type: Photovoltaic system total power
+  type: photovoltaic system total power
+  instance: 1
+  meters: [3]
+
+- original_name: CS
+  type: cooling systems total power
   instance: 1
   meters: [4]
 
-- original_name: CS
-  type: Cooling Systems total power
-  instance: 1
-  meters: [5]
-
 - original_name: CHP
-  type: Combined heat and power    
+  type: combined heat and power total
   instance: 1
   multiple: true  
-  meters: [6]
+  meters: [5]
 
 - original_name: BA
-  type: Backgorund appliance 
-  instance: 2   
-  multiple: true   
-  meters: [7]
-
-
+  type: server computer
+  instance: 1
+  multiple: true
+  meters: [6]

--- a/metadata/building2.yaml
+++ b/metadata/building2.yaml
@@ -1,40 +1,41 @@
-instance: 2  
-original_name: Office_Offenbach   
+instance: 2
+original_name: Office_Offenbach
 elec_meters:
   1: &sided_whole_building
     site_meter: true
     device_model: SIDED_whole_building
-  2: *sided_whole_building
-  3: &emonitor
-    submeter_of: 0 
+  2: &emonitor      # Meter for EVSE
+    submeter_of: 1
     device_model: eMonitor
+  3: *emonitor      # Meter for PV
+  4: *emonitor      # Meter for CS  
+  5: *emonitor      # Meter for CHP
+  6: *emonitor      # Meter for BA
 
 appliances:
 - original_name: EVSE
-  type: Plug-in electric vehicle station
+  type: plug-in electric vehicle station
   instance: 1
-  meters: [3]   
+  meters: [2]   
 
 - original_name: PV
-  type: Photovoltaic system total power
+  type: photovoltaic system total power
+  instance: 1
+  meters: [3]
+
+- original_name: CS
+  type: cooling systems total power
   instance: 1
   meters: [4]
 
-- original_name: CS
-  type: Cooling Systems total power
-  instance: 1
-  meters: [5]
-
 - original_name: CHP
-  type: Combined heat and power   
+  type: combined heat and power total
   instance: 1
   multiple: true  
-  meters: [6]
+  meters: [5]
 
 - original_name: BA
-  type: Backgorund appliance 
-  instance: 2   
-  multiple: true   
-  meters: [7]
-
-
+  type: server computer
+  instance: 1
+  multiple: true
+  meters: [6]

--- a/metadata/building3.yaml
+++ b/metadata/building3.yaml
@@ -1,40 +1,41 @@
-instance: 3   
-original_name: Office_LA  
+instance: 3
+original_name: Office_LA
 elec_meters:
   1: &sided_whole_building
     site_meter: true
     device_model: SIDED_whole_building
-  2: *sided_whole_building
-  3: &emonitor
-    submeter_of: 0 
+  2: &emonitor      # Meter for EVSE
+    submeter_of: 1
     device_model: eMonitor
+  3: *emonitor      # Meter for PV
+  4: *emonitor      # Meter for CS  
+  5: *emonitor      # Meter for CHP
+  6: *emonitor      # Meter for BA
 
 appliances:
 - original_name: EVSE
-  type: Plug-in electric vehicle station
+  type: plug-in electric vehicle station
   instance: 1
-  meters: [3]   
+  meters: [2]   
 
 - original_name: PV
-  type: Photovoltaic system total power
+  type: photovoltaic system total power
+  instance: 1
+  meters: [3]
+
+- original_name: CS
+  type: cooling systems total power
   instance: 1
   meters: [4]
 
-- original_name: CS
-  type: Cooling Systems total power
-  instance: 1
-  meters: [5]
-
 - original_name: CHP
-  type: Combined heat and power   
+  type: combined heat and power total
   instance: 1
   multiple: true  
-  meters: [6]
+  meters: [5]
 
 - original_name: BA
-  type: Backgorund appliance 
-  instance: 2   
-  multiple: true   
-  meters: [7]
-
-
+  type: server computer
+  instance: 1
+  multiple: true
+  meters: [6]

--- a/metadata/building4.yaml
+++ b/metadata/building4.yaml
@@ -1,38 +1,41 @@
-instance: 4   
-original_name: Logistic_Tokyo  
+instance: 4
+original_name: Logistic_Tokyo
 elec_meters:
   1: &sided_whole_building
     site_meter: true
     device_model: SIDED_whole_building
-  2: *sided_whole_building
-  3: &emonitor
-    submeter_of: 0 
+  2: &emonitor      # Meter for EVSE
+    submeter_of: 1
     device_model: eMonitor
+  3: *emonitor      # Meter for PV
+  4: *emonitor      # Meter for CS  
+  5: *emonitor      # Meter for CHP
+  6: *emonitor      # Meter for BA
 
 appliances:
 - original_name: EVSE
-  type: Plug-in electric vehicle station
+  type: plug-in electric vehicle station
   instance: 1
-  meters: [3]   
+  meters: [2]   
 
 - original_name: PV
-  type: Photovoltaic system total power
+  type: photovoltaic system total power
+  instance: 1
+  meters: [3]
+
+- original_name: CS
+  type: cooling systems total power
   instance: 1
   meters: [4]
 
-- original_name: CS
-  type: Cooling Systems total power
-  instance: 1
-  meters: [5]
-
 - original_name: CHP
-  type: Combined heat and power   
+  type: combined heat and power total
   instance: 1
   multiple: true  
-  meters: [6]
+  meters: [5]
 
 - original_name: BA
-  type: Backgorund appliance 
-  instance: 2   
-  multiple: true   
-  meters: [7]
+  type: server computer
+  instance: 1
+  multiple: true
+  meters: [6]

--- a/metadata/building5.yaml
+++ b/metadata/building5.yaml
@@ -1,40 +1,41 @@
-instance: 5  
-original_name: Office_Offenbach 
+instance: 5
+original_name: Logistic_Offenbach
 elec_meters:
   1: &sided_whole_building
     site_meter: true
     device_model: SIDED_whole_building
-  2: *sided_whole_building
-  3: &emonitor
-    submeter_of: 0 
+  2: &emonitor      # Meter for EVSE
+    submeter_of: 1
     device_model: eMonitor
+  3: *emonitor      # Meter for PV
+  4: *emonitor      # Meter for CS  
+  5: *emonitor      # Meter for CHP
+  6: *emonitor      # Meter for BA
 
 appliances:
 - original_name: EVSE
-  type: Plug-in electric vehicle station
+  type: plug-in electric vehicle station
   instance: 1
-  meters: [3]   
+  meters: [2]   
 
 - original_name: PV
-  type: Photovoltaic system total power
+  type: photovoltaic system total power
+  instance: 1
+  meters: [3]
+
+- original_name: CS
+  type: cooling systems total power
   instance: 1
   meters: [4]
 
-- original_name: CS
-  type: Cooling Systems total power
-  instance: 1
-  meters: [5]
-
 - original_name: CHP
-  type: Combined heat and power   
+  type: combined heat and power total
   instance: 1
   multiple: true  
-  meters: [6]
+  meters: [5]
 
 - original_name: BA
-  type: Backgorund appliance 
-  instance: 2   
-  multiple: true   
-  meters: [7]
-
-
+  type: server computer
+  instance: 1
+  multiple: true
+  meters: [6]

--- a/metadata/building6.yaml
+++ b/metadata/building6.yaml
@@ -1,40 +1,41 @@
-instance: 6   
-original_name: Logistic_LA   
+instance: 6
+original_name: Logistic_LA
 elec_meters:
   1: &sided_whole_building
     site_meter: true
     device_model: SIDED_whole_building
-  2: *sided_whole_building
-  3: &emonitor
-    submeter_of: 0 
+  2: &emonitor      # Meter for EVSE
+    submeter_of: 1
     device_model: eMonitor
+  3: *emonitor      # Meter for PV
+  4: *emonitor      # Meter for CS  
+  5: *emonitor      # Meter for CHP
+  6: *emonitor      # Meter for BA
 
 appliances:
 - original_name: EVSE
-  type: Plug-in electric vehicle station
+  type: plug-in electric vehicle station
   instance: 1
-  meters: [3]   
+  meters: [2]   
 
 - original_name: PV
-  type: Photovoltaic system total power
+  type: photovoltaic system total power
+  instance: 1
+  meters: [3]
+
+- original_name: CS
+  type: cooling systems total power
   instance: 1
   meters: [4]
 
-- original_name: CS
-  type: Cooling Systems total power
-  instance: 1
-  meters: [5]
-
 - original_name: CHP
-  type: Combined heat and power    
+  type: combined heat and power total
   instance: 1
   multiple: true  
-  meters: [6]
+  meters: [5]
 
 - original_name: BA
-  type: Backgorund appliance 
-  instance: 2   
-  multiple: true   
-  meters: [7]
-
-
+  type: server computer
+  instance: 1
+  multiple: true
+  meters: [6]

--- a/metadata/building7.yaml
+++ b/metadata/building7.yaml
@@ -1,40 +1,41 @@
-instance: 7  
-original_name: Dealer_Tokyo   
+instance: 7
+original_name: Dealer_Tokyo
 elec_meters:
   1: &sided_whole_building
     site_meter: true
     device_model: SIDED_whole_building
-  2: *sided_whole_building
-  3: &emonitor
-    submeter_of: 0 
+  2: &emonitor      # Meter for EVSE
+    submeter_of: 1
     device_model: eMonitor
+  3: *emonitor      # Meter for PV
+  4: *emonitor      # Meter for CS  
+  5: *emonitor      # Meter for CHP
+  6: *emonitor      # Meter for BA
 
 appliances:
 - original_name: EVSE
-  type: Plug-in electric vehicle station
+  type: plug-in electric vehicle station
   instance: 1
-  meters: [3]   
+  meters: [2]   
 
 - original_name: PV
-  type: Photovoltaic system total power
+  type: photovoltaic system total power
+  instance: 1
+  meters: [3]
+
+- original_name: CS
+  type: cooling systems total power
   instance: 1
   meters: [4]
 
-- original_name: CS
-  type: Cooling Systems total power
-  instance: 1
-  meters: [5]
-
 - original_name: CHP
-  type: Combined heat and power    
+  type: combined heat and power total
   instance: 1
   multiple: true  
-  meters: [6]
+  meters: [5]
 
 - original_name: BA
-  type: Backgorund appliance 
-  instance: 2   
-  multiple: true   
-  meters: [7]
-
-
+  type: server computer
+  instance: 1
+  multiple: true
+  meters: [6]

--- a/metadata/building8.yaml
+++ b/metadata/building8.yaml
@@ -1,41 +1,41 @@
-instance: 8   
-original_name: Dealer_Offenbach 
+instance: 8
+original_name: Dealer_Offenbach
 elec_meters:
   1: &sided_whole_building
     site_meter: true
     device_model: SIDED_whole_building
-  2: *sided_whole_building
-  3: &emonitor
-    submeter_of: 0 
+  2: &emonitor      # Meter for EVSE
+    submeter_of: 1
     device_model: eMonitor
+  3: *emonitor      # Meter for PV
+  4: *emonitor      # Meter for CS  
+  5: *emonitor      # Meter for CHP
+  6: *emonitor      # Meter for BA
 
 appliances:
 - original_name: EVSE
-  type: Plug-in electric vehicle station
+  type: plug-in electric vehicle station
   instance: 1
-  meters: [3]   
+  meters: [2]   
 
 - original_name: PV
-  type: Photovoltaic system total power
+  type: photovoltaic system total power
+  instance: 1
+  meters: [3]
+
+- original_name: CS
+  type: cooling systems total power
   instance: 1
   meters: [4]
 
-- original_name: CS
-  type: Cooling Systems total power
-  instance: 1
-  meters: [5]
-
 - original_name: CHP
-  type: Combined heat and power   
+  type: combined heat and power total
   instance: 1
   multiple: true  
-  meters: [6]
+  meters: [5]
 
 - original_name: BA
-  type: Backgorund appliance 
-  instance: 2   
-  multiple: true   
-  meters: [7]
-
-
-
+  type: server computer
+  instance: 1
+  multiple: true
+  meters: [6]

--- a/metadata/building9.yaml
+++ b/metadata/building9.yaml
@@ -1,40 +1,41 @@
-instance: 9  
-original_name: Dealer_LA 
+instance: 9
+original_name: Dealer_LA
 elec_meters:
   1: &sided_whole_building
     site_meter: true
     device_model: SIDED_whole_building
-  2: *sided_whole_building
-  3: &emonitor
-    submeter_of: 0 
+  2: &emonitor      # Meter for EVSE
+    submeter_of: 1
     device_model: eMonitor
+  3: *emonitor      # Meter for PV
+  4: *emonitor      # Meter for CS  
+  5: *emonitor      # Meter for CHP
+  6: *emonitor      # Meter for BA
 
 appliances:
 - original_name: EVSE
-  type: Plug-in electric vehicle station
+  type: plug-in electric vehicle station
   instance: 1
-  meters: [3]   
+  meters: [2]   
 
 - original_name: PV
-  type: Photovoltaic system total power
+  type: photovoltaic system total power
+  instance: 1
+  meters: [3]
+
+- original_name: CS
+  type: cooling systems total power
   instance: 1
   meters: [4]
 
-- original_name: CS
-  type: Cooling Systems total power
-  instance: 1
-  meters: [5]
-
 - original_name: CHP
-  type: Combined heat and power   
+  type: combined heat and power total
   instance: 1
   multiple: true  
-  meters: [6]
+  meters: [5]
 
 - original_name: BA
-  type: Backgorund appliance 
-  instance: 2   
-  multiple: true   
-  meters: [7]
-
-
+  type: server computer
+  instance: 1
+  multiple: true
+  meters: [6]

--- a/metadata/meter_devices.yaml
+++ b/metadata/meter_devices.yaml
@@ -12,7 +12,7 @@ eMonitor:
     lower_limit: -50000
   wireless: false
 
- SIDED_whole_building:
+SIDED_whole_building:
   description: >
     Each facility type in the dataset contains profiles for five different appliances: Electric Vehicle Supply Equipment (EVSE), Cooling Systems (CS), Photo  Voltaic (PV), Combined Heat and Power (CHP), and Background Appliances (BA), which sums up all smaller devices such as personal computers, various machinery, servers, or other household appliances.
     The EVSE, BA and SC are consumers of electrical energy, while PV and CHP are producers.


### PR DESCRIPTION
Updated all building YAML files to standardize appliance types, correct meter assignments, and fix typos. Changed 'Background appliance' to 'server computer', unified meter numbering, and fixed indentation and formatting inconsistencies. Also corrected the 'SIDED_whole_building' key indentation in meter_devices.yaml.